### PR TITLE
feat:context

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,3 @@
 {
-    "presets": ["@babel/preset-env"],
-    "plugins": ["@babel/plugin-proposal-class-properties"]
+    "presets": ["@babel/preset-env"]
     }

--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-PORT=9001
-serviceUrl=http://localhost:9000
+PORT=8000
+serviceUrl=http://localhost:9001

--- a/src/config/configurations.js
+++ b/src/config/configurations.js
@@ -2,7 +2,7 @@ import dotenv from 'dotenv';
 
 const envVars = dotenv.config().parsed;
 const configurations = {
-  port: envVars.PORT,
+  PORT: envVars.PORT,
   serviceUrl: envVars.serviceUrl
 };
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,1 +1,1 @@
-export{default as configurations} from './configurations'
+export { default as config } from './configurations';

--- a/src/datasource/Trainee.js
+++ b/src/datasource/Trainee.js
@@ -1,0 +1,32 @@
+/* eslint-disable no-new-object */
+import { RESTDataSource } from 'apollo-datasource-rest';
+import {config} from '../config';
+
+export default class TraineeApi extends RESTDataSource {
+    constructor() {
+        super();
+        this.baseURL = `${config.serviceUrl}/api/trainee`;
+    }
+
+    willSendRequest(request) {
+        request.headers.set('Authorization', this.context.token);
+    }
+
+    async getAll() {
+        return this.get('/getall');
+    }
+
+    createTrainee(user) {
+        const newTrainee = new Object({ ...user });
+        return this.post('/create', newTrainee);
+    }
+
+    updateTrainee(user) {
+        const traineeupdate = new Object({ ...user });
+        return this.put('/update', traineeupdate);
+    }
+
+    deleteTrainee(id) {
+        return this.delete(`/delete/${id}`);
+    }
+}

--- a/src/datasource/User.js
+++ b/src/datasource/User.js
@@ -1,14 +1,17 @@
 import { RESTDataSource } from 'apollo-datasource-rest';
-import configurations from '../config/configurations';
+import {config} from '../config';
 
 export default class UserAPI extends RESTDataSource {
     constructor() {
       super();
-      this.baseURL = `${configurations.serviceUrl}/api/user`;
+      this.baseURL = `${config.serviceUrl}/api/user`;
+    }
+    willSendRequest(request) {
+      request.headers.set('Authorization', this.context.token);
     }
   
-    loginUser(payLoad) {
-      return this.post('/login', payLoad);
+    loginUser(payload) {
+      return this.post('/login', payload);
     }
   
     getMe() {

--- a/src/datasource/index.js
+++ b/src/datasource/index.js
@@ -1,1 +1,2 @@
-export { default as UserAPI } from './User';
+export { default as UserApi } from './User';
+export { default as TraineeApi } from './Trainee';

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,17 @@
-import schema from './modules';
+import config from './config/configurations';
 import Server from './server';
-import configurations from './config/configurations';
+import Schema from './modules';
 
-const server = new Server(configurations);
-(() => {
-server.bootstrap().setupApollo(schema);
-})();
+
+const server = new Server(config);
+
+const { typeDefs, resolvers } = Schema;
+
+const initServer = async () => {
+  server.setupApollo({ resolvers, typeDefs });
+};
+
+initServer();
+
+
+export default server;

--- a/src/lib/constant.js
+++ b/src/lib/constant.js
@@ -1,4 +1,4 @@
-export default {
+export const constant = {
   subscriptions: {
     TRAINEE_ADDED: 'TRAINEE_ADDED',
     TRAINEE_UPDATED: 'TRAINEE_UPDATED',

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -1,7 +1,7 @@
 import { fileLoader, mergeTypes } from 'merge-graphql-schemas';
 import path from 'path';
 import * as user from './user';
-import * as trainee from './trainee';
+import { Mutation, Query, traineeSubscription } from './trainee';
 
 const typesArray = fileLoader(path.join(__dirname, './**/*.graphql'));
 
@@ -10,16 +10,16 @@ const typeDefs = mergeTypes(typesArray, { all: true });
 export default {
   resolvers: {
     Query: {
-      ...user.Query,
-      ...trainee.Query
+      ...user.getMe,
+      ...Query,
     },
     Mutation: {
-      ...trainee.Mutation,
-      ...user.Mutation
+      ...Mutation,
+      ...user.loginMutation,
     },
     Subscription: {
-      ...trainee.traineeSubscription
-    }
+      ...traineeSubscription,
+    },
   },
-  typeDefs
+  typeDefs,
 };

--- a/src/modules/schema.graphql
+++ b/src/modules/schema.graphql
@@ -1,17 +1,17 @@
 type Query {
-    getMyProfile: User!
-     getAllTrainees: [User]
-    getTrainee(id: ID!): User!
+    getMe: User!
+    getAll: [User]
 }
 
 type Mutation {
-    createTrainee(user: CreateUserInput): User!
-    updateTrainee(id: ID!, role: String, name: String, email: String): User!
-    deleteTrainee(id:ID!): ID!
-    loginUser(payLoad: LoginCredentials): String
-} 
+  createTrainee(user: CreateUserInput): createResponse!
+  updateTrainee(user: UpdateUserInput): UpdatedUser!
+  deleteTrainee(id: ID!): deletedOutput!
+  loginUser(payload: Payload): loginOutput!
+}
+
 type Subscription {
-    traineeAdded: User!
-    traineeUpdated: User!
-    traineeDeleted:ID!
+  traineeAdded: createResponse!
+  traineeUpdated: UpdatedUser!
+  traineeDeleted: deletedOutput!
 }

--- a/src/modules/trainee/mutation.js
+++ b/src/modules/trainee/mutation.js
@@ -1,26 +1,51 @@
 import userInstance from '../../service/user';
 import pubsub from '../pubsub';
-import constants from '../../lib/constant';
+import { constant } from '../../lib/constant';
 
 export default {
-  createTrainee: (parent, args, context) => {
-    const { user } = args;
-    const addedUser = userInstance.createUser(user);
-    pubsub.publish(constants.subscriptions.TRAINEE_ADDED, { traineeAdded: addedUser });
-    return addedUser;
+  createTrainee: async (parent, args, context) => {
+    try {
+      const { user: { name, email, password, role, createdBy } } = args;
+      const { dataSources: { traineeAPI } } = context;
+      const response = await traineeAPI.createTrainee({name, email, createdBy, password, role });
+      pubsub.publish(constant.subscriptions.TRAINEE_ADDED, { traineeAdded: response });
+      return response;
+    } catch(error) {
+      return {
+        message: 'Database under maintainance',
+        status: 503
+      }
+    }
   },
-  updateTrainee: (parent, args, context) => {
-    const {
-      id, role, name, email
-    } = args;
-    const updatedUser = userInstance.updateUser(id, name, email, role);
-    pubsub.publish(constants.subscriptions.TRAINEE_UPDATED, { traineeUpdated: updatedUser });
-    return updatedUser;
+
+  updateTrainee: async (parent, args, context) => {
+    try {
+      const { user } = args;
+      const { dataSources: { traineeAPI } } = context;
+      const response = await traineeAPI.updateTrainee(user);
+      pubsub.publish(constant.subscriptions.TRAINEE_UPDATED, { traineeUpdated: response });
+      return response;
+    } catch (error) {
+      return {
+        message: 'Database under maintaince',
+        status: 503
+      }
+    }
+    
   },
-  deleteTrainee: (parent, args, context) => {
-    const { id } = args;
-    const deletedID = userInstance.deleteUser(id);
-    pubsub.publish(constants.subscriptions.TRAINEE_DELETED, { traineeDeleted: deletedID });
-    return deletedID;
-  }
+
+  deleteTrainee: async (parent, args, context) => {
+    try {
+      const { id } = args;
+      const { dataSources: { traineeAPI } } = context;
+      const response = await traineeAPI.deleteTrainee(id);
+      pubsub.publish(constant.subscriptions.TRAINEE_DELETED, { traineeDeleted: response });
+      return response;
+    } catch (error) {
+      return { 
+        message: 'Database under maintaince',
+        status: 503
+      }
+    }
+  },
 };

--- a/src/modules/trainee/query.js
+++ b/src/modules/trainee/query.js
@@ -1,10 +1,10 @@
 import user from '../../service/user';
 
 export default {
-
-  getAllTrainees: () => user.getAllUsers(),
-  getTrainee: (parent, args) => {
-    const { id } = args;
-    return user.getUser(id);
-  }
+  // getAll: () => user.getAll(),
+  getAll: async (parent, args, context) => {
+    const { dataSources: { traineeApi } } = context;
+    const response = await traineeApi.getAll();
+    return response.data.records;
+  },
 };

--- a/src/modules/trainee/subscription.js
+++ b/src/modules/trainee/subscription.js
@@ -1,15 +1,15 @@
 import pubsub from '../pubsub';
-import constants from '../../lib/constant';
+import { constant } from '../../lib/constant';
 
 export default {
   traineeAdded: {
-    subscribe: () => pubsub.asyncIterator([constants.subscriptions.TRAINEE_ADDED])
+    subscribe: () => pubsub.asyncIterator([constant.subscriptions.TRAINEE_ADDED])
   },
   traineeUpdated: {
-    subscribe: () => pubsub.asyncIterator([constants.subscriptions.TRAINEE_UPDATED])
+    subscribe: () => pubsub.asyncIterator([constant.subscriptions.TRAINEE_UPDATED])
   },
   traineeDeleted: {
-    subscribe: () => pubsub.asyncIterator([constants.subscriptions.TRAINEE_DELETED])
+    subscribe: () => pubsub.asyncIterator([constant.subscriptions.TRAINEE_DELETED])
   }
 };
 

--- a/src/modules/trainee/types.graphql
+++ b/src/modules/trainee/types.graphql
@@ -2,8 +2,35 @@ input CreateUserInput {
     name: String!
     email: String!
     role: String!
-} 
-input LoginCredentials{
-    email: String!
     password: String!
-} 
+    createdBy: String!
+}
+
+type getAllType {
+  _id: String!
+  name: String!
+  email: String!
+  role: String!
+  originalId: String!
+  createdAt: String!
+}
+
+input UpdateUserInput {
+    originalId:ID!
+    name: String
+    email: String
+    role: String
+    password: String
+    updatedBy: String!
+}
+
+type UpdatedUser {
+    status: Int!
+    message: String!
+    data: User
+}
+
+type deletedOutput {
+    status: Int!
+    message: String!
+}

--- a/src/modules/user/index.js
+++ b/src/modules/user/index.js
@@ -1,2 +1,2 @@
-export { default as Query } from './query';
-export { default as Mutation } from './mutation.js';
+export { default as getMe } from './query';
+export { default as loginMutation } from './mutation';

--- a/src/modules/user/mutation.js
+++ b/src/modules/user/mutation.js
@@ -1,8 +1,16 @@
 export default {
     loginUser: async (parent, args, context) => {
-      const { payLoad: { email, password } } = args;
-      const { dataSources: { userAPI } } = context;
-      const response = await userAPI.loginUser({ email, password });
-      return response.data;
+      try {
+        const { payload: { email, password } } = args;
+        console.log(email, password)
+        const { dataSources: { userAPI } } = context;
+        const response = await userAPI.loginUser({ email, password });
+        return response;
+      } catch (error) {
+        return {
+          message: 'Server under maintaince',
+          status: 503
+        }
+      }
     }
   };

--- a/src/modules/user/query.js
+++ b/src/modules/user/query.js
@@ -1,5 +1,5 @@
 export default {
-  getMyProfile: async (parent, args, context) => {
+  getMe: async (parent, args, context) => {
     const { dataSources: { userAPI } } = context;
     const response = await userAPI.getMe();
     return response.data;

--- a/src/modules/user/types.graphql
+++ b/src/modules/user/types.graphql
@@ -1,6 +1,25 @@
-type User{
-    id:ID!
-    name:String!
-    email:String!
+type User {
+    id: ID!
+    name: String!
+    email: String!
     role: String!
+    password: String!
+    createdBy: String!
+}
+
+input Payload {
+  email: String!
+  password: String!
+}
+
+type loginOutput {
+  message: String!
+  status: Int!
+  data: String
+}
+
+type createResponse{
+  message: String!
+  status: String!
+  data: User
 }

--- a/src/service/user.js
+++ b/src/service/user.js
@@ -1,11 +1,13 @@
+/* eslint-disable no-console */
 class User {
   constructor() {
     this.users = new Map();
     this.id = 0;
   }
 
-  getAllUsers() {
-    return this.users.values();
+  getAll() {
+    const details = this.users.values();
+    return details;
   }
 
   createUser(user) {
@@ -14,21 +16,18 @@ class User {
     return this.users.get(this.id);
   }
 
-  updateUser(id, role, name, email) {
-    const user = this.users.get(Number(id));
-    this.users.set(Number(id), {
-      ...user, role, name, email
-    });
+  updateUser(users, id) {
+    console.log('Inside update method User');
+    const traineeId = this.users.get(Number(id));
+    this.users.set(Number(id), { ...traineeId, ...users });
     return this.users.get(Number(id));
   }
 
   deleteUser(id) {
-    this.users.delete(Number(id));
-    return id;
-  }
-
-  getUser(id) {
-    return this.users.get(Number(id));
+    const delRec = this.data.get(Number(id));
+    this.data.delete(Number(id));
+    return delRec;
   }
 }
-export default new User();
+const user = new User();
+export default user;


### PR DESCRIPTION
1.Add the trainee data source and add all the methods in there with respect to the available rest endpoints for trainees.
2.Update the schema of the entities with respect to the response of the above APIs.
3.Replace the mock implementation calls with actual API calls in your resolvers.

- Steps

-Add the context key in the Apollo Server instance, where you will get the token from the req header and return that token from there so that it is available in context.
-Add a function in your data source willSendRequest where you will set the header of the request which you will get from the context.
-Now as the last step make all changes according to the acceptance criteria.
